### PR TITLE
テナント側の日記コンテンツが表示できるかをテストする #18

### DIFF
--- a/django_tenants_diary/diary/fixtures/tests/diary.json
+++ b/django_tenants_diary/diary/fixtures/tests/diary.json
@@ -1,0 +1,24 @@
+[
+	{
+		"model": "diary.post",
+		"pk": 1,
+		"fields": {
+			"user": 1,
+			"title": "日記1",
+			"body": "<p>日記だよ",
+			"created_at": "2021-06-02T05:25:20.822Z",
+			"updated_at": "2021-06-02T05:25:20.822Z"
+		}
+	},
+	{
+		"model": "diary.post",
+		"pk": 2,
+		"fields": {
+			"user": 1,
+			"title": "日記2",
+			"body": "<p>日記2だよ",
+			"created_at": "2021-06-02T05:25:34.454Z",
+			"updated_at": "2021-06-02T05:25:34.454Z"
+		}
+	}
+]

--- a/django_tenants_diary/diary/fixtures/tests/user.json
+++ b/django_tenants_diary/diary/fixtures/tests/user.json
@@ -1,0 +1,20 @@
+[
+	{
+		"model": "user.user",
+		"pk": 1,
+		"fields": {
+			"password": "pbkdf2_sha256$260000$DyDDajllUkNqhCzOnfYzCZ$oy17ovtU0JbxHHffZUxMhr+Nc7QUahHvFtQwQDoXXuw=",
+			"last_login": "2021-06-02T05:25:02.668Z",
+			"is_superuser": true,
+			"username": "kokubo",
+			"first_name": "",
+			"last_name": "",
+			"email": "kokubo@example.com",
+			"is_staff": true,
+			"is_active": true,
+			"date_joined": "2021-06-02T05:24:45.361Z",
+			"groups": [],
+			"user_permissions": []
+		}
+	}
+]

--- a/django_tenants_diary/diary/tests.py
+++ b/django_tenants_diary/diary/tests.py
@@ -41,5 +41,6 @@ class IndexPageTest(TenantTestCase):
   def test_is_post(self):
     '''トップページを開いた際日記コンテンツが表示されていること'''
     response = self.c.get(reverse('diary:index'))
+    self.assertEqual(2, len(response.context['posts']))
     self.assertEqual('日記1', response.context['posts'][0].title)
     self.assertEqual('<p>日記だよ', response.context['posts'][0].body)

--- a/django_tenants_diary/diary/tests.py
+++ b/django_tenants_diary/diary/tests.py
@@ -2,21 +2,33 @@ from django_tenants.test.cases import TenantTestCase
 from django_tenants.test.client import TenantClient
 from django.urls import reverse
 from tenants.models import Tenant
+from user.models import User
+from diary.models import Post
+from django.core.management import call_command
 
-class PremiumUserTest(TenantTestCase):
-  
+
+class IndexPageTest(TenantTestCase):
+  @staticmethod
+  def get_test_schema_name():
+    '''テスト用テナントのschema名を定義'''
+    return 'test'
+
   @classmethod
   def setup_tenant(cls, tenant):
     """
     テスト用テナントの設定
     """
-    tenant.is_premium = True
+    tenant.is_premium = True # プレミアムユーザー
     return tenant
 
   def setUp(self) -> None:
-    super().setUp()
+    super(IndexPageTest, self).setUp()
     # テスト用テナントでアクセスするためのクライアント
     self.c = TenantClient(self.tenant)
+    
+    # 日記コンテンツを投入する(schema指定しなくてもテスト用テナントに入る)
+    call_command('loaddata', 'diary/fixtures/tests/user.json')
+    call_command('loaddata', 'diary/fixtures/tests/diary.json')
   
   def tearDown(self) -> None:
     pass
@@ -24,5 +36,10 @@ class PremiumUserTest(TenantTestCase):
   def test_is_premium(self):
     '''プレミアムユーザーのテナントのトップページを開いたときプレミアムフラグがついている事'''
     response = self.c.get(reverse('diary:index'))
-    print(response.status_code)
     self.assertEqual(True, response.context['tenant'].is_premium)
+  
+  def test_is_post(self):
+    '''トップページを開いた際日記コンテンツが表示されていること'''
+    response = self.c.get(reverse('diary:index'))
+    self.assertEqual('日記1', response.context['posts'][0].title)
+    self.assertEqual('<p>日記だよ', response.context['posts'][0].body)


### PR DESCRIPTION
# テスト結果
コンテナ内で下記を実行。
```
root@ca55fd183867:/code# python manage.py test diary.tests
Creating test database for alias 'default'...
System check identified no issues (0 silenced).
Installed 1 object(s) from 1 fixture(s)
Installed 2 object(s) from 1 fixture(s)
.Installed 1 object(s) from 1 fixture(s)
Installed 2 object(s) from 1 fixture(s)
.
----------------------------------------------------------------------
Ran 2 tests in 0.985s

OK
Destroying test database for alias 'default'...
```